### PR TITLE
Add aircraft type to labels and aircraft info

### DIFF
--- a/WebATM/proxy/handlers/simulation.py
+++ b/WebATM/proxy/handlers/simulation.py
@@ -116,6 +116,7 @@ def on_acdata_received(data):
                 empty_traffic_data = {
                     "id": [],
                     "lat": [],
+                    "actype": [], # this is only sent by bluesky/amvlab
                     "lon": [],
                     "alt": [],
                     "tas": [],

--- a/WebATM/static/ts/src/core/App.ts
+++ b/WebATM/static/ts/src/core/App.ts
@@ -748,6 +748,7 @@ export class App {
                 trk: [],
                 vs: [],
                 tas: [],
+                actype: [],
                 inconf: [],
                 tcpamax: [],
                 nconf_cur: 0,

--- a/WebATM/static/ts/src/core/StateManager.ts
+++ b/WebATM/static/ts/src/core/StateManager.ts
@@ -66,6 +66,7 @@ export class StateManager {
                 showAircraftId: true,
                 showAircraftSpeed: true,
                 showAircraftAltitude: true,
+                showAircraftType: true,
                 showAircraftTrails: false,
                 showProtectedZones: false,
                 showRoutes: true,
@@ -266,6 +267,7 @@ export class StateManager {
         lon: number;
         alt: number;
         tas: number;
+        actype: string;
         trk: number;
         vs: number;
         inconf: boolean;
@@ -283,6 +285,7 @@ export class StateManager {
             lon: aircraftData.lon[index],
             alt: aircraftData.alt[index],
             tas: aircraftData.tas[index],
+            actype: aircraftData.actype && aircraftData.actype[index] ? aircraftData.actype[index] : '',
             trk: aircraftData.trk[index],
             vs: aircraftData.vs[index],
             inconf: aircraftData.inconf[index],
@@ -296,6 +299,7 @@ export class StateManager {
         lon: number;
         alt: number;
         tas: number;
+        actype: string;
         trk: number;
         vs: number;
         inconf: boolean;
@@ -313,6 +317,7 @@ export class StateManager {
             lon: aircraftData.lon[index],
             alt: aircraftData.alt[index],
             tas: aircraftData.tas[index],
+            actype: aircraftData.actype && aircraftData.actype[index] ? aircraftData.actype[index] : '',
             trk: aircraftData.trk[index],
             vs: aircraftData.vs[index],
             inconf: aircraftData.inconf[index],

--- a/WebATM/static/ts/src/data/types.ts
+++ b/WebATM/static/ts/src/data/types.ts
@@ -32,6 +32,7 @@ export interface AircraftData extends EntityData {
     tas: number[];          // True Airspeed
     cas?: number[];         // Calibrated Airspeed (optional - may not be sent by backend yet)
     gs?: number[];          // Ground Speed (optional - may not be sent by backend yet)
+    actype?: string[];
     inconf: boolean[];      // In conflict status
     tcpamax: number[];      // Time to closest point of approach
     nconf_cur: number;      // Current number of conflicts
@@ -426,6 +427,7 @@ export interface DisplayOptions {
   showAircraftId: boolean;
   showAircraftSpeed: boolean;
   showAircraftAltitude: boolean;
+  showAircraftType: boolean;
   showAircraftTrails: boolean;
   showProtectedZones: boolean;
   showRoutes: boolean;

--- a/WebATM/static/ts/src/ui/map/aircraft/AircraftCreationManager.ts
+++ b/WebATM/static/ts/src/ui/map/aircraft/AircraftCreationManager.ts
@@ -17,7 +17,7 @@ import { logger } from '../../../utils/Logger';
  */
 interface AircraftData {
     id: string;
-    type: string;
+    actype: string; // Aircraft type
     altDisplay: number;
     altUnit: AltitudeUnit;
     spdDisplay: number;
@@ -362,7 +362,7 @@ export class AircraftCreationManager {
 
         this.currentAircraftData = {
             id: id,
-            type: type,
+            actype: type,
             altDisplay: parseFloat(alt),
             altUnit: currentAltUnit,
             spdDisplay: parseFloat(spd),
@@ -848,7 +848,7 @@ export class AircraftCreationManager {
         logger.debug('AircraftCreationManager', `Unit conversion: ${this.currentAircraftData.altDisplay}${this.currentAircraftData.altUnit} → ${altFeet}ft, ${this.currentAircraftData.spdDisplay}${this.currentAircraftData.spdUnit} → ${speedKnots}kts`);
 
         // Build and send CRE command
-        const command = `CRE ${this.currentAircraftData.id},${this.currentAircraftData.type},${position[1]},${position[0]},${heading},${altFeet},${speedKnots}`;
+        const command = `CRE ${this.currentAircraftData.id},${this.currentAircraftData.actype},${position[1]},${position[0]},${heading},${altFeet},${speedKnots}`;
 
         logger.info('AircraftCreationManager', `Creating aircraft with command: ${command}`);
         logger.debug('AircraftCreationManager', `Position: [${position[1]}, ${position[0]}], Heading: ${heading}°`);

--- a/WebATM/static/ts/src/ui/map/aircraft/AircraftRenderer.ts
+++ b/WebATM/static/ts/src/ui/map/aircraft/AircraftRenderer.ts
@@ -59,6 +59,7 @@ export class AircraftRenderer extends EntityRenderer<AircraftData> {
      */
     protected buildEntityLabel(aircraftData: AircraftData, index: number): string {
         const id = aircraftData.id[index];
+        const actype = aircraftData.actype && aircraftData.actype[index] ? aircraftData.actype[index] : '';
         const altitude = aircraftData.alt ? aircraftData.alt[index] : 0;
         const verticalSpeed = aircraftData.vs ? aircraftData.vs[index] : 0;
 
@@ -84,6 +85,10 @@ export class AircraftRenderer extends EntityRenderer<AircraftData> {
 
         if (this.displayOptions.showAircraftId) {
             labelParts.push(id);
+        }
+
+        if (this.displayOptions.showAircraftType && actype) {
+            labelParts.push(actype);
         }
 
         if (this.displayOptions.showAircraftSpeed && speed > 0) {

--- a/WebATM/static/ts/src/ui/panels/left/DisplayOptionsPanel.ts
+++ b/WebATM/static/ts/src/ui/panels/left/DisplayOptionsPanel.ts
@@ -102,6 +102,7 @@ export class DisplayOptionsPanel extends BasePanel {
         const showAircraftId = storage.get<boolean>('show-aircraft-id') ?? displayOptions.showAircraftId;
         const showAircraftSpeed = storage.get<boolean>('show-aircraft-speed') ?? displayOptions.showAircraftSpeed;
         const showAircraftAltitude = storage.get<boolean>('show-aircraft-altitude') ?? displayOptions.showAircraftAltitude;
+        const showAircraftType = storage.get<boolean>('show-aircraft-type') ?? displayOptions.showAircraftType;
         const showAircraftTrails = storage.get<boolean>('show-aircraft-trails') ?? displayOptions.showAircraftTrails;
         const showProtectedZones = storage.get<boolean>('show-protected-zones') ?? displayOptions.showProtectedZones;
 
@@ -150,6 +151,7 @@ export class DisplayOptionsPanel extends BasePanel {
             showAircraftId,
             showAircraftSpeed,
             showAircraftAltitude,
+            showAircraftType,
             showAircraftTrails,
             showProtectedZones,
             showShapes,
@@ -216,6 +218,9 @@ export class DisplayOptionsPanel extends BasePanel {
 
         const showAircraftAltitudeCheckbox = document.getElementById('show-aircraft-altitude') as HTMLInputElement;
         if (showAircraftAltitudeCheckbox) showAircraftAltitudeCheckbox.checked = showAircraftAltitude;
+
+        const showAircraftTypeCheckbox = document.getElementById('show-aircraft-type') as HTMLInputElement;
+        if (showAircraftTypeCheckbox) showAircraftTypeCheckbox.checked = showAircraftType;
 
         const showAircraftTrailsCheckbox = document.getElementById('show-aircraft-trails') as HTMLInputElement;
         if (showAircraftTrailsCheckbox) showAircraftTrailsCheckbox.checked = showAircraftTrails;
@@ -685,12 +690,13 @@ export class DisplayOptionsPanel extends BasePanel {
                 // Save the main labels toggle state
                 storage.set('show-aircraft-labels', checked);
 
-                // Update all three label sub-options to match
+                // Update all four label sub-options to match
                 storage.set('show-aircraft-id', checked);
                 storage.set('show-aircraft-speed', checked);
                 storage.set('show-aircraft-altitude', checked);
+                storage.set('show-aircraft-type', checked);
 
-                // Update the UI checkboxes for ID, Speed, and Altitude
+                // Update the UI checkboxes for ID, Speed, Altitude, and Type
                 const showAircraftIdCheckbox = document.getElementById('show-aircraft-id') as HTMLInputElement;
                 if (showAircraftIdCheckbox) showAircraftIdCheckbox.checked = checked;
 
@@ -700,20 +706,25 @@ export class DisplayOptionsPanel extends BasePanel {
                 const showAircraftAltitudeCheckbox = document.getElementById('show-aircraft-altitude') as HTMLInputElement;
                 if (showAircraftAltitudeCheckbox) showAircraftAltitudeCheckbox.checked = checked;
 
+                const showAircraftTypeCheckbox = document.getElementById('show-aircraft-type') as HTMLInputElement;
+                if (showAircraftTypeCheckbox) showAircraftTypeCheckbox.checked = checked;
+
                 // Toggle visibility of sub-option containers
                 this.toggleSubOptionContainers([
                     'show-aircraft-id-container',
                     'show-aircraft-speed-container',
-                    'show-aircraft-altitude-container'
+                    'show-aircraft-altitude-container',
+                    'show-aircraft-type-container'
                 ], checked);
 
-                // Update state manager with all four values
+                // Update state manager with all five values
                 if (this.stateManager) {
                     this.stateManager.updateDisplayOptions({
                         showAircraftLabels: checked,
                         showAircraftId: checked,
                         showAircraftSpeed: checked,
-                        showAircraftAltitude: checked
+                        showAircraftAltitude: checked,
+                        showAircraftType: checked
                     });
                 }
             });
@@ -751,6 +762,18 @@ export class DisplayOptionsPanel extends BasePanel {
                 storage.set('show-aircraft-altitude', checked);
                 if (this.stateManager) {
                     this.stateManager.updateDisplayOptions({ showAircraftAltitude: checked });
+                }
+            });
+        }
+
+        // Aircraft type visibility
+        const showAircraftTypeCheckbox = document.getElementById('show-aircraft-type') as HTMLInputElement;
+        if (showAircraftTypeCheckbox) {
+            showAircraftTypeCheckbox.addEventListener('change', (e) => {
+                const checked = (e.target as HTMLInputElement).checked;
+                storage.set('show-aircraft-type', checked);
+                if (this.stateManager) {
+                    this.stateManager.updateDisplayOptions({ showAircraftType: checked });
                 }
             });
         }

--- a/WebATM/static/ts/src/ui/panels/right/AircraftInfoPanel.ts
+++ b/WebATM/static/ts/src/ui/panels/right/AircraftInfoPanel.ts
@@ -112,6 +112,7 @@ export class AircraftInfoPanel extends BasePanel {
 
         // Get aircraft data (in BlueSky units: alt in ft, speeds in kt, vs in ft/s)
         const aircraftId = data.id[index];
+        const aircraftType = data.actype && data.actype[index] ? data.actype[index] : 'N/A';
         const lat = data.lat[index];
         const lon = data.lon[index];
         const altFeet = data.alt[index];
@@ -125,7 +126,7 @@ export class AircraftInfoPanel extends BasePanel {
 
         // Create info object for comparison
         const currentInfo = {
-            aircraftId, lat, lon, altFeet, casKnots, tasKnots, gsKnots, trk, vsFtPerSec, inconf, tcpamax,
+            aircraftId, aircraftType, lat, lon, altFeet, casKnots, tasKnots, gsKnots, trk, vsFtPerSec, inconf, tcpamax,
             // Include display options in comparison to trigger update on unit changes
             speedUnit: this.displayOptions.speedUnit,
             altUnit: this.displayOptions.altitudeUnit,
@@ -166,6 +167,10 @@ export class AircraftInfoPanel extends BasePanel {
                 <div class="info-row">
                     <span class="info-label">Aircraft ID:</span>
                     <span class="info-value copyable-value" data-field="id">${aircraftId}</span>
+                </div>
+                <div class="info-row">
+                    <span class="info-label">Aircraft Type:</span>
+                    <span class="info-value copyable-value" data-field="actype">${aircraftType}</span>
                 </div>
                 <div class="info-row">
                     <span class="info-label">Latitude:</span>

--- a/WebATM/templates/index.html
+++ b/WebATM/templates/index.html
@@ -166,6 +166,10 @@
                                 <input type="checkbox" id="show-aircraft-altitude" checked>
                                 Aircraft Altitude
                             </label>
+                            <label class="checkbox-label route-sub-option" id="show-aircraft-type-container">
+                                <input type="checkbox" id="show-aircraft-type" checked>
+                                Aircraft Type
+                            </label>
                             <label class="checkbox-label">
                                 <input type="checkbox" id="show-aircraft-trails">
                                 Aircraft Trails


### PR DESCRIPTION
Here we add the aircraft type the map labels and aircraft info panel. Note that this requires sending the aircraft type via `screenio.py` from BlueSky simulation. Note that this is currently only implemented in the BlueSky fork from amvlab. Nevertheless, it is still compatible with TU Delft BlueSky. Aircraft type will just appear as N/A. The only way to get this information would be to run a `POS` command on the aircraft id.