### PR TITLE
Fix 3D aircraft altitude rendering across different scene origins

### DIFF
--- a/frontend/src/ui/map/aircraft/Aircraft3DRenderer.ts
+++ b/frontend/src/ui/map/aircraft/Aircraft3DRenderer.ts
@@ -313,8 +313,8 @@ class Aircraft3DCustomLayer extends CustomLayer3D {
             path,
             (gltf) => {
                 this.loadingModels.delete(path);
-                this.normalizeModel(gltf.scene, path);
-                this.loadedModels.set(path, gltf.scene);
+                const centered = this.normalizeModel(gltf.scene, path);
+                this.loadedModels.set(path, centered);
                 logger.info('Aircraft3DCustomLayer', `Aircraft model loaded: ${path}`);
                 this.processPendingAircraft(path);
             },
@@ -340,11 +340,12 @@ class Aircraft3DCustomLayer extends CustomLayer3D {
      * per-aircraft scale is then computed in updateMeshTransform*
      * using real-world dimensions for the aircraft's ICAO type.
      */
-    private normalizeModel(model: THREE.Group, path: string): void {
+    private normalizeModel(model: THREE.Group, path: string): THREE.Group {
         // Record raw bounding-box extent so per-aircraft scaling can
         // convert GLB units to real-world meters for any ICAO type.
         const box = new THREE.Box3().setFromObject(model);
         const size = box.getSize(new THREE.Vector3());
+        const center = box.getCenter(new THREE.Vector3());
         const rawMax = Math.max(size.x, size.y, size.z) || 1;
         this.modelRawMaxDim.set(path, rawMax);
 
@@ -408,7 +409,19 @@ class Aircraft3DCustomLayer extends CustomLayer3D {
         // The rotation is applied in updateMeshTransform() via the transform matrix
         // This ensures heading rotation works correctly
 
-        logger.debug('Aircraft3DCustomLayer', `Model normalized: path=${path}, rawMax=${rawMax.toFixed(2)}, size=${size.x.toFixed(1)}x${size.y.toFixed(1)}x${size.z.toFixed(1)}, anisotropy=${maxAnisotropy}`);
+        // Wrap the GLB scene so the cached model's local origin sits at the
+        // geometric center. GLBs are authored with origins at the wheels,
+        // nose, etc., which makes the visible body float above/below the
+        // route altitude line (the route waypoint spheres are plain geometry
+        // centered at altitudeMeters). Recentering also makes yaw rotation
+        // pivot through the aircraft's vertical centerline.
+        model.position.sub(center);
+        const wrapper = new THREE.Group();
+        wrapper.add(model);
+
+        logger.debug('Aircraft3DCustomLayer', `Model normalized: path=${path}, rawMax=${rawMax.toFixed(2)}, size=${size.x.toFixed(1)}x${size.y.toFixed(1)}x${size.z.toFixed(1)}, center=(${center.x.toFixed(2)},${center.y.toFixed(2)},${center.z.toFixed(2)}), anisotropy=${maxAnisotropy}`);
+
+        return wrapper;
     }
 
     /**

--- a/frontend/src/ui/map/aircraft/Aircraft3DRenderer.ts
+++ b/frontend/src/ui/map/aircraft/Aircraft3DRenderer.ts
@@ -717,7 +717,7 @@ class Aircraft3DCustomLayer extends CustomLayer3D {
 
         const originMercator = MercatorCoordinate.fromLngLat([this.sceneOrigin.lng, this.sceneOrigin.lat]);
         const targetMercator = MercatorCoordinate.fromLngLat([lng, lat]);
-        
+
         const mercatorPerMeter = originMercator.meterInMercatorCoordinateUnits();
         const dEast = targetMercator.x - originMercator.x;
         const dEastMeter = dEast / mercatorPerMeter;
@@ -725,6 +725,22 @@ class Aircraft3DCustomLayer extends CustomLayer3D {
         const dNorthMeter = dNorth / mercatorPerMeter;
 
         return { east: dEastMeter, north: dNorthMeter };
+    }
+
+    /**
+     * Pre-scale altitude so that, after the camera projection multiplies
+     * mesh.position.y by `meterInMercatorCoordinateUnits` at the SCENE
+     * ORIGIN's lat, the resulting world Z equals altitude × per-point
+     * mercator scale. This makes altitude rendering independent of which
+     * scene origin this layer happens to be using, so the 3D aircraft
+     * (whose origin is the centroid of all aircraft) and the 3D route
+     * (whose origin is the selected aircraft) agree on visual height.
+     */
+    private altitudeForOrigin(altMeters: number, lat: number, lon: number): number {
+        if (!this.sceneOrigin) return altMeters;
+        const pointMpm = MercatorCoordinate.fromLngLat([lon, lat]).meterInMercatorCoordinateUnits();
+        const originMpm = MercatorCoordinate.fromLngLat([this.sceneOrigin.lng, this.sceneOrigin.lat]).meterInMercatorCoordinateUnits();
+        return altMeters * (pointMpm / originMpm);
     }
 
     /**
@@ -814,8 +830,9 @@ class Aircraft3DCustomLayer extends CustomLayer3D {
         // Calculate position relative to scene origin in meters
         const relativePos = this.calculateRelativePosition(data.lat, data.lon);
 
-        // Altitude already in meters from BlueSky
-        const altitudeMeters = data.alt;
+        // Altitude in meters from BlueSky, lat-corrected so the world Z
+        // matches the route renderer (which has a different scene origin).
+        const altitudeMeters = this.altitudeForOrigin(data.alt, data.lat, data.lon);
 
         // Convert aircraft heading to radians (0° = North, clockwise)
         const headingRad = THREE.MathUtils.degToRad(data.hdg);

--- a/frontend/src/ui/map/aircraft/Aircraft3DRenderer.ts
+++ b/frontend/src/ui/map/aircraft/Aircraft3DRenderer.ts
@@ -490,6 +490,20 @@ class Aircraft3DCustomLayer extends CustomLayer3D {
 
         for (let i = 0; i < aircraftData.id.length; i++) {
             const id = aircraftData.id[i];
+
+            // Skip aircraft with invalid coordinates — matches the 2D
+            // renderer's guard. MercatorCoordinate.fromLngLat throws on
+            // out-of-range values, which would crash the whole tick.
+            const lat = aircraftData.lat[i];
+            const lon = aircraftData.lon[i];
+            if (
+                typeof lat !== 'number' || typeof lon !== 'number' ||
+                isNaN(lat) || isNaN(lon) ||
+                lat < -90 || lat > 90 || lon < -180 || lon > 180
+            ) {
+                continue;
+            }
+
             activeIds.add(id);
 
             const actype = aircraftData.actype?.[i] ?? '';

--- a/frontend/src/ui/map/aircraft/Aircraft3DRenderer.ts
+++ b/frontend/src/ui/map/aircraft/Aircraft3DRenderer.ts
@@ -313,8 +313,8 @@ class Aircraft3DCustomLayer extends CustomLayer3D {
             path,
             (gltf) => {
                 this.loadingModels.delete(path);
-                const centered = this.normalizeModel(gltf.scene, path);
-                this.loadedModels.set(path, centered);
+                this.normalizeModel(gltf.scene, path);
+                this.loadedModels.set(path, gltf.scene);
                 logger.info('Aircraft3DCustomLayer', `Aircraft model loaded: ${path}`);
                 this.processPendingAircraft(path);
             },
@@ -340,12 +340,11 @@ class Aircraft3DCustomLayer extends CustomLayer3D {
      * per-aircraft scale is then computed in updateMeshTransform*
      * using real-world dimensions for the aircraft's ICAO type.
      */
-    private normalizeModel(model: THREE.Group, path: string): THREE.Group {
+    private normalizeModel(model: THREE.Group, path: string): void {
         // Record raw bounding-box extent so per-aircraft scaling can
         // convert GLB units to real-world meters for any ICAO type.
         const box = new THREE.Box3().setFromObject(model);
         const size = box.getSize(new THREE.Vector3());
-        const center = box.getCenter(new THREE.Vector3());
         const rawMax = Math.max(size.x, size.y, size.z) || 1;
         this.modelRawMaxDim.set(path, rawMax);
 
@@ -409,19 +408,7 @@ class Aircraft3DCustomLayer extends CustomLayer3D {
         // The rotation is applied in updateMeshTransform() via the transform matrix
         // This ensures heading rotation works correctly
 
-        // Wrap the GLB scene so the cached model's local origin sits at the
-        // geometric center. GLBs are authored with origins at the wheels,
-        // nose, etc., which makes the visible body float above/below the
-        // route altitude line (the route waypoint spheres are plain geometry
-        // centered at altitudeMeters). Recentering also makes yaw rotation
-        // pivot through the aircraft's vertical centerline.
-        model.position.sub(center);
-        const wrapper = new THREE.Group();
-        wrapper.add(model);
-
-        logger.debug('Aircraft3DCustomLayer', `Model normalized: path=${path}, rawMax=${rawMax.toFixed(2)}, size=${size.x.toFixed(1)}x${size.y.toFixed(1)}x${size.z.toFixed(1)}, center=(${center.x.toFixed(2)},${center.y.toFixed(2)},${center.z.toFixed(2)}), anisotropy=${maxAnisotropy}`);
-
-        return wrapper;
+        logger.debug('Aircraft3DCustomLayer', `Model normalized: path=${path}, rawMax=${rawMax.toFixed(2)}, size=${size.x.toFixed(1)}x${size.y.toFixed(1)}x${size.z.toFixed(1)}, anisotropy=${maxAnisotropy}`);
     }
 
     /**

--- a/frontend/src/ui/map/aircraft/AircraftRoute3DRenderer.ts
+++ b/frontend/src/ui/map/aircraft/AircraftRoute3DRenderer.ts
@@ -371,10 +371,23 @@ class AircraftRoute3DCustomLayer extends CustomLayer3D {
     /**
      * Convert lat/lon/alt to scene-relative meter coordinates for the mercator group.
      * Scene axes after group rotation: x=east, y=up, z=north. Altitude in meters.
+     *
+     * Altitude is pre-scaled by the per-point / scene-origin mercator-per-meter
+     * ratio so that, after the camera projection multiplies y by the scene
+     * origin's mercator-per-meter, world Z equals altitude × per-point
+     * mercator scale. This is what the 3D aircraft renderer also does, so
+     * both layers agree on visual height regardless of where each puts its
+     * scene origin.
      */
     private toScenePos(lat: number, lon: number, altitudeMeters: number): THREE.Vector3 {
         const rel = this.calculateRelativePosition(lat, lon);
-        return new THREE.Vector3(rel.east, altitudeMeters, rel.north);
+        if (!this.sceneOrigin) {
+            return new THREE.Vector3(rel.east, altitudeMeters, rel.north);
+        }
+        const pointMpm = MercatorCoordinate.fromLngLat([lon, lat]).meterInMercatorCoordinateUnits();
+        const originMpm = MercatorCoordinate.fromLngLat([this.sceneOrigin.lng, this.sceneOrigin.lat]).meterInMercatorCoordinateUnits();
+        const altScaled = altitudeMeters * (pointMpm / originMpm);
+        return new THREE.Vector3(rel.east, altScaled, rel.north);
     }
 
     private calculateRelativePosition(lat: number, lng: number): { east: number; north: number } {


### PR DESCRIPTION
## Summary
This PR fixes a visual inconsistency where 3D aircraft and route altitudes appeared at different heights depending on the scene origin latitude. The issue occurred because the camera projection applies a latitude-dependent mercator scale factor, but altitude scaling wasn't accounting for differences between the aircraft renderer's scene origin (centroid of all aircraft) and the route renderer's scene origin (selected aircraft).

## Key Changes

- **Aircraft3DRenderer.ts**:
  - Added coordinate validation guard to skip aircraft with invalid lat/lon values before attempting mercator conversion, preventing crashes during rendering
  - Introduced `altitudeForOrigin()` method that pre-scales altitude by the ratio of per-point to scene-origin mercator scales
  - Updated altitude calculation to use the new scaling method, ensuring visual height matches the route renderer

- **AircraftRoute3DRenderer.ts**:
  - Updated `toScenePos()` method to apply the same altitude scaling logic as the aircraft renderer
  - Added detailed documentation explaining the altitude pre-scaling approach
  - Ensures both 3D layers agree on visual aircraft height regardless of their respective scene origins

## Implementation Details

The fix works by pre-scaling altitude values before they're used in mesh positioning. When the camera projection later multiplies the Y coordinate by the scene origin's mercator-per-meter value, the result correctly represents the altitude scaled by the per-point mercator scale. This makes altitude rendering independent of scene origin selection.

Both renderers now use the same scaling formula: `altitude × (pointMercatorPerMeter / originMercatorPerMeter)`, ensuring visual consistency across the 3D map.

https://claude.ai/code/session_01UeMMQGCjBB7xMRcM5FXAoa