### PR TITLE
Add functionality to stream output

### DIFF
--- a/WebATM/server/routes.py
+++ b/WebATM/server/routes.py
@@ -11,7 +11,7 @@ import socket
 import time
 from pathlib import Path
 
-from flask import current_app, jsonify, render_template, request
+from flask import current_app, jsonify, render_template, request, send_file
 from werkzeug.utils import secure_filename
 
 from ..logger import get_logger
@@ -458,6 +458,7 @@ def register_basic_routes(app, session_manager):
                             "scenario": str(scenario_dir),
                             "plugins": str(plugins_dir),
                             "settings": str(path_obj / "settings.cfg"),
+                            "output": str(path_obj / "output"),
                         },
                     }
                 )
@@ -616,6 +617,7 @@ def register_basic_routes(app, session_manager):
                 "scenario": {"extension": ".scn", "directory": "scenario"},
                 "plugins": {"extension": ".py", "directory": "plugins"},
                 "settings": {"extension": ".cfg", "filepath": "settings.cfg"},
+                "output": {"extension": "", "directory": "output"},
             }
 
             if file_type not in file_type_config:
@@ -654,17 +656,22 @@ def register_basic_routes(app, session_manager):
                                 }
                             )
 
-                    # Add files with the specified extension
-                    for file_path in target_dir.glob(f"*{config['extension']}"):
-                        stat_info = file_path.stat()
-                        files.append(
-                            {
-                                "filename": file_path.name,
-                                "size": stat_info.st_size,
-                                "modified": stat_info.st_mtime,
-                                "type": "file",
-                            }
-                        )
+                    # Add files (filtered by extension if specified, all files otherwise)
+                    if config["extension"]:
+                        file_iter = target_dir.glob(f"*{config['extension']}")
+                    else:
+                        file_iter = target_dir.iterdir()
+                    for file_path in file_iter:
+                        if file_path.is_file():
+                            stat_info = file_path.stat()
+                            files.append(
+                                {
+                                    "filename": file_path.name,
+                                    "size": stat_info.st_size,
+                                    "modified": stat_info.st_mtime,
+                                    "type": "file",
+                                }
+                            )
 
             return jsonify(
                 {
@@ -699,6 +706,7 @@ def register_basic_routes(app, session_manager):
                 "scenario": {"extension": ".scn", "directory": "scenario"},
                 "plugins": {"extension": ".py", "directory": "plugins"},
                 "settings": {"extension": ".cfg", "filepath": "settings.cfg"},
+                "output": {"extension": "", "directory": "output"},
             }
 
             if file_type not in file_type_config:
@@ -803,8 +811,12 @@ def register_basic_routes(app, session_manager):
                             }
                         )
 
-                # Add files with the specified extension
-                for file_path in target_dir.glob(f"*{config['extension']}"):
+                # Add files (filtered by extension if specified, all files otherwise)
+                if config["extension"]:
+                    file_iter = target_dir.glob(f"*{config['extension']}")
+                else:
+                    file_iter = target_dir.iterdir()
+                for file_path in file_iter:
                     if file_path.is_file():
                         stat_info = file_path.stat()
                         files.append(
@@ -849,6 +861,136 @@ def register_basic_routes(app, session_manager):
             logger.error(f"Error browsing {file_type} directory: {e}")
             return jsonify(
                 {"success": False, "error": f"Failed to browse directory: {str(e)}"}
+            ), 500
+
+    def _validate_output_path(filepath):
+        """Validate and resolve a filepath within the output directory.
+
+        Returns (resolved_path, error_response) tuple. If validation fails,
+        resolved_path is None and error_response contains the Flask response.
+        """
+        if not hasattr(current_app, "bluesky_base_path"):
+            return None, (
+                jsonify(
+                    {"success": False, "error": "BlueSky base path not configured"}
+                ),
+                400,
+            )
+
+        base_path = Path(current_app.bluesky_base_path)
+        output_base = base_path / "output"
+
+        # Clean and validate the path
+        normalized = Path(filepath).as_posix()
+        path_parts = [
+            part
+            for part in normalized.split("/")
+            if part and part != "." and part != ".."
+        ]
+
+        if not path_parts:
+            return None, (
+                jsonify({"success": False, "error": "No file specified"}),
+                400,
+            )
+
+        target = output_base
+        for part in path_parts:
+            target = target / part
+
+        # Security check
+        try:
+            resolved_target = target.resolve()
+            resolved_base = output_base.resolve()
+            if not str(resolved_target).startswith(str(resolved_base)):
+                return None, (
+                    jsonify(
+                        {
+                            "success": False,
+                            "error": "Access denied: Path outside allowed directory",
+                        }
+                    ),
+                    403,
+                )
+        except (OSError, ValueError):
+            return None, (
+                jsonify({"success": False, "error": "Invalid path"}),
+                400,
+            )
+
+        if not resolved_target.exists() or not resolved_target.is_file():
+            return None, (
+                jsonify({"success": False, "error": "File not found"}),
+                404,
+            )
+
+        return resolved_target, None
+
+    @app.route("/api/bluesky/output/download/<path:filepath>", methods=["GET"])
+    def download_output_file(filepath):
+        """Download a file from the BlueSky output directory."""
+        try:
+            resolved_path, error = _validate_output_path(filepath)
+            if error:
+                return error
+
+            return send_file(
+                resolved_path,
+                as_attachment=True,
+                download_name=resolved_path.name,
+            )
+
+        except Exception as e:
+            logger.error(f"Error downloading output file: {e}")
+            return jsonify(
+                {"success": False, "error": f"Failed to download file: {str(e)}"}
+            ), 500
+
+    @app.route("/api/bluesky/output/content/<path:filepath>", methods=["GET"])
+    def get_output_file_content(filepath):
+        """Read content from an output file for log streaming.
+
+        Query params:
+            offset: byte offset to read from (0 = use tail mode for initial load)
+            lines: max lines for initial tail load (default 200)
+        """
+        try:
+            resolved_path, error = _validate_output_path(filepath)
+            if error:
+                return error
+
+            offset = request.args.get("offset", type=int, default=0)
+            max_lines = request.args.get("lines", type=int, default=200)
+            file_size = resolved_path.stat().st_size
+
+            if offset > 0:
+                # Incremental read from offset to end
+                with open(resolved_path, errors="replace") as f:
+                    f.seek(min(offset, file_size))
+                    content = f.read()
+                    new_offset = f.tell()
+            else:
+                # Initial load: tail the last N lines
+                with open(resolved_path, errors="replace") as f:
+                    all_lines = f.readlines()
+                    tail_lines = all_lines[-max_lines:]
+                    content = "".join(tail_lines)
+                    new_offset = f.tell()
+
+            return jsonify(
+                {
+                    "success": True,
+                    "content": content,
+                    "offset": new_offset,
+                    "total_size": file_size,
+                    "filename": resolved_path.name,
+                }
+            )
+
+        except Exception as e:
+            logger.error(f"Error reading output file content: {e}")
+            return jsonify(
+                {"success": False, "error": f"Failed to read file: {str(e)}"}
             ), 500
 
     @app.route("/api/bluesky/<file_type>/<filename>", methods=["DELETE"])
@@ -938,6 +1080,7 @@ def register_basic_routes(app, session_manager):
                         "scenario": str(base_path / "scenario"),
                         "plugins": str(base_path / "plugins"),
                         "settings": str(base_path / "settings.cfg"),
+                        "output": str(base_path / "output"),
                     },
                     "path_exists": base_path.exists(),
                     "path_writable": os.access(str(base_path), os.W_OK)

--- a/WebATM/static/css/style.css
+++ b/WebATM/static/css/style.css
@@ -1173,6 +1173,255 @@ body {
     color: #4CAF50;
 }
 
+.echo-tab-bar {
+    display: flex;
+    gap: 2px;
+}
+
+.echo-tab {
+    background-color: #404040;
+    color: #aaa;
+    border: 1px solid #606060;
+    padding: calc(var(--console-font-size) * 0.2) calc(var(--console-font-size) * 0.6);
+    cursor: pointer;
+    border-radius: 3px;
+    font-size: var(--console-font-size);
+    min-height: calc(var(--console-font-size) * 1.8);
+    transition: background-color 0.15s, color 0.15s;
+}
+
+.echo-tab:hover {
+    background-color: #505050;
+    color: #ddd;
+}
+
+.echo-tab.active {
+    background-color: #4CAF50;
+    color: #fff;
+    border-color: #4CAF50;
+}
+
+.echo-header-controls {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+#log-stream-filename {
+    font-size: var(--echo-font-size);
+    color: #888;
+    font-family: 'Courier New', monospace;
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.log-stream-output {
+    flex: 1;
+    overflow-y: auto;
+    padding: 4px 8px;
+    font-family: 'Courier New', monospace;
+    font-size: var(--echo-font-size);
+    background-color: #000000;
+    color: #e0e0e0;
+    scrollbar-width: thin;
+    scrollbar-color: #808080 #2b2b2b;
+}
+
+.log-stream-line {
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.4;
+}
+
+.log-stream-output::-webkit-scrollbar {
+    width: 8px;
+}
+
+.log-stream-output::-webkit-scrollbar-track {
+    background: #2b2b2b;
+    border-radius: 4px;
+}
+
+.log-stream-output::-webkit-scrollbar-thumb {
+    background-color: #808080;
+    border-radius: 4px;
+    border: 2px solid #2b2b2b;
+}
+
+.log-stream-output::-webkit-scrollbar-thumb:hover {
+    background-color: #999999;
+}
+
+#output-log-container {
+    flex-direction: column;
+}
+
+.output-breadcrumbs {
+    padding: 4px 8px;
+    background-color: #1a1a1a;
+    border-bottom: 1px solid #333;
+    font-size: var(--echo-font-size);
+    font-family: 'Courier New', monospace;
+}
+
+.output-crumb-link {
+    color: #4CAF50;
+    cursor: pointer;
+}
+
+.output-crumb-link:hover {
+    text-decoration: underline;
+}
+
+.output-crumb-active {
+    color: #fff;
+    font-weight: bold;
+}
+
+.output-crumb-sep {
+    color: #666;
+    margin: 0 2px;
+}
+
+.output-file-row {
+    display: flex;
+    align-items: center;
+    padding: 3px 8px;
+    border-bottom: 1px solid #222;
+    font-size: var(--echo-font-size);
+    gap: 6px;
+}
+
+.output-file-row:hover {
+    background-color: #1a1a1a;
+}
+
+.output-folder-row {
+    cursor: pointer;
+    color: #4CAF50;
+}
+
+.output-file-icon {
+    flex-shrink: 0;
+    width: 16px;
+    text-align: center;
+}
+
+.output-file-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: 'Courier New', monospace;
+}
+
+.output-file-meta {
+    flex-shrink: 0;
+    color: #666;
+    font-size: calc(var(--echo-font-size) - 1px);
+    white-space: nowrap;
+}
+
+.output-file-actions {
+    flex-shrink: 0;
+    display: flex;
+    gap: 3px;
+}
+
+.output-file-actions .console-btn {
+    font-size: calc(var(--echo-font-size) - 1px);
+    padding: 1px 5px;
+    min-height: 0;
+}
+
+.output-browser-message {
+    padding: 12px;
+    text-align: center;
+    color: #666;
+    font-size: var(--echo-font-size);
+}
+
+.output-browser-error {
+    color: #f44336;
+}
+
+.log-search-bar {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    background-color: #1a1a1a;
+    border-top: 1px solid #444;
+}
+
+.log-search-field {
+    flex: 1;
+    padding: 2px 6px;
+    background-color: #111;
+    border: 1px solid #444;
+    border-radius: 3px;
+    color: #ccc;
+    font-size: var(--echo-font-size);
+    font-family: 'Courier New', monospace;
+    min-width: 0;
+}
+
+.log-search-field:focus {
+    outline: none;
+    border-color: #4CAF50;
+}
+
+.log-search-count {
+    font-size: calc(var(--echo-font-size) - 1px);
+    color: #888;
+    white-space: nowrap;
+    min-width: 50px;
+    text-align: center;
+}
+
+.log-search-btn {
+    font-size: var(--echo-font-size) !important;
+    padding: 1px 6px !important;
+    min-height: 0 !important;
+    line-height: 1.2;
+}
+
+.log-search-highlight {
+    background-color: #665500;
+    color: #fff;
+    border-radius: 1px;
+}
+
+.log-search-highlight.active {
+    background-color: #ff8c00;
+    color: #000;
+}
+
+.output-search-bar {
+    padding: 4px 8px;
+    background-color: #1a1a1a;
+    border-bottom: 1px solid #333;
+}
+
+.output-search-field {
+    width: 100%;
+    padding: 3px 6px;
+    background-color: #111;
+    border: 1px solid #444;
+    border-radius: 3px;
+    color: #ccc;
+    font-size: var(--echo-font-size);
+    font-family: 'Courier New', monospace;
+    box-sizing: border-box;
+}
+
+.output-search-field:focus {
+    outline: none;
+    border-color: #4CAF50;
+}
+
 .console-btn {
     background-color: #404040;
     color: white;

--- a/WebATM/templates/index.html
+++ b/WebATM/templates/index.html
@@ -54,7 +54,6 @@
                     <button id="menu-dropdown-btn" class="control-btn dropdown-btn" title="Menu">☰</button>
                     <div id="menu-dropdown" class="dropdown-menu" style="display: none;">
                         <a href="#" id="upload-files-btn" class="dropdown-item">Upload Files</a>
-                        <a href="#" id="download-logs-btn" class="dropdown-item">Download Simulation Logs</a>
                     </div>
                 </div>
                 <button id="settings-btn" class="control-btn" title="Settings">⚙️</button>
@@ -523,10 +522,40 @@
 
             <div class="echo-section">
                 <div class="echo-header">
-                    <h3>Echo Messages</h3>
-                    <button id="clear-echo" class="console-btn">Clear</button>
+                    <div class="echo-tab-bar">
+                        <button id="echo-tab-btn" class="echo-tab active">Echo</button>
+                        <button id="log-stream-tab-btn" class="echo-tab">Output Log</button>
+                    </div>
+                    <div class="echo-header-controls">
+                        <span id="log-stream-filename"></span>
+                        <button id="clear-echo" class="console-btn">Clear</button>
+                        <button id="refresh-output-files" class="console-btn" style="display: none;">Reload</button>
+                        <button id="clear-log-stream" class="console-btn" style="display: none;">Clear</button>
+                        <button id="stop-log-stream" class="console-btn" style="display: none;">Exit Stream</button>
+                    </div>
                 </div>
                 <div class="echo-output" id="echo-output">
+                </div>
+                <div id="output-log-container" style="display: none; flex: 1; overflow: hidden;">
+                    <div id="output-file-browser" style="display: flex; flex-direction: column; flex: 1; overflow: hidden;">
+                        <div id="output-not-configured" style="padding: 12px; color: #ffa500; display: none;">
+                            BlueSky base directory not configured. Configure it in Settings.
+                        </div>
+                        <div class="output-search-bar">
+                            <input id="output-search-input" type="text" placeholder="Filter files..." class="output-search-field">
+                        </div>
+                        <div id="output-file-list" style="flex: 1; overflow-y: auto;">
+                        </div>
+                    </div>
+                    <div class="log-stream-output" id="log-stream-output" style="display: none;">
+                    </div>
+                    <div id="log-search-bar" class="log-search-bar" style="display: none;">
+                        <input id="log-search-input" type="text" placeholder="Search log..." class="log-search-field">
+                        <span id="log-search-count" class="log-search-count"></span>
+                        <button id="log-search-prev" class="console-btn log-search-btn">&#9650;</button>
+                        <button id="log-search-next" class="console-btn log-search-btn">&#9660;</button>
+                        <button id="log-search-close" class="console-btn log-search-btn">&times;</button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -617,6 +646,7 @@
                                 <div>📁 Scenarios: <span id="scenario-path-display-settings">-</span></div>
                                 <div>🧩 Plugins: <span id="plugins-path-display-settings">-</span></div>
                                 <div>⚙️ Settings: <span id="settings-path-display-settings">-</span></div>
+                                <div>📄 Output: <span id="output-path-display-settings">-</span></div>
                             </div>
                         </div>
                     </div>
@@ -932,6 +962,7 @@
                                 <div>📁 Scenarios: <span id="scenario-path-display">-</span></div>
                                 <div>🧩 Plugins: <span id="plugins-path-display">-</span></div>
                                 <div>⚙️ Settings: <span id="settings-path-display">-</span></div>
+                                <div>📄 Output: <span id="output-path-display">-</span></div>
                             </div>
                         </div>
                     </div>
@@ -1027,35 +1058,6 @@
             </div>
             <div class="modal-footer">
                 <button id="upload-files-close-footer" class="btn-secondary">Close</button>
-            </div>
-        </div>
-    </div>
-
-    <!-- Download Logs Modal -->
-    <div id="download-logs-modal" class="modal" style="display: none;">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3>Download Simulation Logs</h3>
-                <button class="modal-close" id="download-logs-close">&times;</button>
-            </div>
-            <div class="modal-body">
-                <div class="setting-group">
-                    <div class="demo-message">
-                        <span class="demo-badge">UNDER DEVELOPMENT</span>
-                        <p><strong>Downloading simulation logs is currently under development.</strong></p>
-                        <p>When fully developed, you will be able to:</p>
-                        <ul style="margin: 10px 0; padding-left: 20px; color: #cccccc;">
-                            <li>Download complete simulation logs</li>
-                            <li>Export aircraft trajectory data</li>
-                            <li>Save conflict detection results</li>
-                            <li>Export performance metrics</li>
-                        </ul>
-                        <p><em>This feature will allow comprehensive analysis of your simulation results.</em></p>
-                    </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button id="download-logs-ok" class="btn-primary">OK</button>
             </div>
         </div>
     </div>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,8 @@ import { App } from './core/App';
 import { echoManager } from './ui/EchoManager';
 import { connectionStatus } from './core/ConnectionStatusService';
 import { logger } from './utils/Logger';
+import './ui/LogStreamManager';
+import './ui/OutputFileBrowser';
 
 /**
  * Entry point for WebATM TypeScript application

--- a/frontend/src/ui/BlueSkyFileManager.ts
+++ b/frontend/src/ui/BlueSkyFileManager.ts
@@ -21,6 +21,7 @@ interface BlueSkyFileStatus {
         scenario: string;
         plugins: string;
         settings: string;
+        output: string;
     };
     path_exists?: boolean;
     path_writable?: boolean;
@@ -174,6 +175,7 @@ export class BlueSkyFileManager {
             document.getElementById('scenario-path-display-settings')!.textContent = status.derived_paths.scenario;
             document.getElementById('plugins-path-display-settings')!.textContent = status.derived_paths.plugins;
             document.getElementById('settings-path-display-settings')!.textContent = status.derived_paths.settings;
+            document.getElementById('output-path-display-settings')!.textContent = status.derived_paths.output;
             statusDiv.style.display = 'block';
         }
 
@@ -191,10 +193,12 @@ export class BlueSkyFileManager {
             const scenarioDisplay = document.getElementById('scenario-path-display');
             const pluginsDisplay = document.getElementById('plugins-path-display');
             const settingsDisplay = document.getElementById('settings-path-display');
-            
+            const outputDisplay = document.getElementById('output-path-display');
+
             if (scenarioDisplay) scenarioDisplay.textContent = status.derived_paths.scenario;
             if (pluginsDisplay) pluginsDisplay.textContent = status.derived_paths.plugins;
             if (settingsDisplay) settingsDisplay.textContent = status.derived_paths.settings;
+            if (outputDisplay) outputDisplay.textContent = status.derived_paths.output;
             configuredStatusDiv.style.display = 'block';
         }
 

--- a/frontend/src/ui/LogStreamManager.ts
+++ b/frontend/src/ui/LogStreamManager.ts
@@ -1,0 +1,437 @@
+import { logger } from '../utils/Logger';
+
+interface StreamContentResponse {
+    success: boolean;
+    content: string;
+    offset: number;
+    total_size: number;
+    filename: string;
+    error?: string;
+}
+
+export class LogStreamManager {
+    private logStreamOutput: HTMLElement | null = null;
+    private echoOutput: HTMLElement | null = null;
+    private outputLogContainer: HTMLElement | null = null;
+    private fileBrowserElement: HTMLElement | null = null;
+    private echoTabBtn: HTMLElement | null = null;
+    private logStreamTabBtn: HTMLElement | null = null;
+    private filenameDisplay: HTMLElement | null = null;
+    private clearEchoBtn: HTMLElement | null = null;
+    private refreshBtn: HTMLElement | null = null;
+    private clearStreamBtn: HTMLElement | null = null;
+    private stopBtn: HTMLElement | null = null;
+
+    // Search elements
+    private searchBar: HTMLElement | null = null;
+    private searchInput: HTMLInputElement | null = null;
+    private searchCount: HTMLElement | null = null;
+    private searchPrevBtn: HTMLElement | null = null;
+    private searchNextBtn: HTMLElement | null = null;
+    private searchCloseBtn: HTMLElement | null = null;
+
+    private pollingInterval: ReturnType<typeof setInterval> | null = null;
+    private currentFilepath: string = '';
+    private currentOffset: number = 0;
+    private isStreaming: boolean = false;
+    private maxLines: number = 1000;
+    private pollIntervalMs: number = 2000;
+    private isInitialized = false;
+
+    // Search state
+    private searchMatches: HTMLElement[] = [];
+    private currentMatchIndex: number = -1;
+    private searchTerm: string = '';
+    private searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+    constructor() {
+        this.init();
+    }
+
+    private init(): void {
+        if (this.isInitialized) return;
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => this.initializeElements());
+        } else {
+            this.initializeElements();
+        }
+    }
+
+    private initializeElements(): void {
+        this.logStreamOutput = document.getElementById('log-stream-output');
+        this.echoOutput = document.getElementById('echo-output');
+        this.outputLogContainer = document.getElementById('output-log-container');
+        this.fileBrowserElement = document.getElementById('output-file-browser');
+        this.echoTabBtn = document.getElementById('echo-tab-btn');
+        this.logStreamTabBtn = document.getElementById('log-stream-tab-btn');
+        this.filenameDisplay = document.getElementById('log-stream-filename');
+        this.clearEchoBtn = document.getElementById('clear-echo');
+        this.refreshBtn = document.getElementById('refresh-output-files');
+        this.clearStreamBtn = document.getElementById('clear-log-stream');
+        this.stopBtn = document.getElementById('stop-log-stream');
+
+        this.searchBar = document.getElementById('log-search-bar');
+        this.searchInput = document.getElementById('log-search-input') as HTMLInputElement;
+        this.searchCount = document.getElementById('log-search-count');
+        this.searchPrevBtn = document.getElementById('log-search-prev');
+        this.searchNextBtn = document.getElementById('log-search-next');
+        this.searchCloseBtn = document.getElementById('log-search-close');
+
+        this.setupEventListeners();
+        this.isInitialized = true;
+        logger.debug('LogStreamManager', 'Initialized');
+    }
+
+    private setupEventListeners(): void {
+        if (this.echoTabBtn) {
+            this.echoTabBtn.addEventListener('click', () => this.switchToEchoView());
+        }
+        if (this.logStreamTabBtn) {
+            this.logStreamTabBtn.addEventListener('click', () => this.switchToLogView());
+        }
+        if (this.refreshBtn) {
+            this.refreshBtn.addEventListener('click', () => {
+                (window as any).outputFileBrowser?.refreshFileList();
+            });
+        }
+        if (this.clearStreamBtn) {
+            this.clearStreamBtn.addEventListener('click', () => {
+                if (this.logStreamOutput) this.logStreamOutput.innerHTML = '';
+                this.clearSearch();
+            });
+        }
+        if (this.stopBtn) {
+            this.stopBtn.addEventListener('click', () => this.stopStreaming());
+        }
+
+        // Search controls
+        if (this.searchInput) {
+            this.searchInput.addEventListener('input', () => {
+                if (this.searchDebounce) clearTimeout(this.searchDebounce);
+                this.searchDebounce = setTimeout(() => this.performSearch(), 200);
+            });
+            this.searchInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    if (e.shiftKey) {
+                        this.prevMatch();
+                    } else {
+                        this.nextMatch();
+                    }
+                }
+                if (e.key === 'Escape') {
+                    this.closeSearch();
+                }
+            });
+        }
+        if (this.searchPrevBtn) {
+            this.searchPrevBtn.addEventListener('click', () => this.prevMatch());
+        }
+        if (this.searchNextBtn) {
+            this.searchNextBtn.addEventListener('click', () => this.nextMatch());
+        }
+        if (this.searchCloseBtn) {
+            this.searchCloseBtn.addEventListener('click', () => this.closeSearch());
+        }
+
+        // Ctrl+F to open search when streaming
+        document.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+                if (this.isStreaming && this.logStreamTabBtn?.classList.contains('active')) {
+                    e.preventDefault();
+                    this.openSearch();
+                }
+            }
+        });
+    }
+
+    public async startStreaming(filepath: string): Promise<void> {
+        this.stopStreaming();
+
+        this.currentFilepath = filepath;
+        this.currentOffset = 0;
+        this.isStreaming = true;
+
+        if (this.logStreamOutput) {
+            this.logStreamOutput.innerHTML = '';
+        }
+
+        this.showStreamView();
+        this.updateControls();
+
+        await this.fetchContent(true);
+
+        this.pollingInterval = setInterval(() => {
+            this.fetchContent(false);
+        }, this.pollIntervalMs);
+
+        logger.info('LogStreamManager', `Streaming: ${filepath}`);
+    }
+
+    public stopStreaming(): void {
+        if (this.pollingInterval) {
+            clearInterval(this.pollingInterval);
+            this.pollingInterval = null;
+        }
+        this.isStreaming = false;
+        this.currentFilepath = '';
+        this.currentOffset = 0;
+        this.closeSearch();
+        this.updateControls();
+        this.showBrowserView();
+    }
+
+    private async fetchContent(isInitial: boolean): Promise<void> {
+        if (!this.currentFilepath) return;
+
+        try {
+            const encodedPath = encodeURIComponent(this.currentFilepath);
+            let url: string;
+
+            if (isInitial) {
+                url = `/api/bluesky/output/content/${encodedPath}?lines=50`;
+            } else {
+                url = `/api/bluesky/output/content/${encodedPath}?offset=${this.currentOffset}`;
+            }
+
+            const response = await fetch(url);
+            const result: StreamContentResponse = await response.json();
+
+            if (result.success) {
+                this.currentOffset = result.offset;
+                if (result.content) {
+                    this.appendContent(result.content, isInitial);
+                }
+            } else {
+                logger.warn('LogStreamManager', `Stream error: ${result.error}`);
+                if (result.error === 'File not found') {
+                    this.stopStreaming();
+                }
+            }
+        } catch (error) {
+            logger.error('LogStreamManager', 'Fetch error:', error);
+        }
+    }
+
+    private appendContent(text: string, replace: boolean = false): void {
+        if (!this.logStreamOutput) return;
+
+        if (replace) {
+            this.logStreamOutput.innerHTML = '';
+        }
+
+        const lines = text.split('\n');
+        const fragment = document.createDocumentFragment();
+
+        for (const line of lines) {
+            const lineEl = document.createElement('div');
+            lineEl.className = 'log-stream-line';
+            lineEl.textContent = line;
+            fragment.appendChild(lineEl);
+        }
+
+        this.logStreamOutput.appendChild(fragment);
+        this.limitLines();
+        this.logStreamOutput.scrollTop = this.logStreamOutput.scrollHeight;
+    }
+
+    private limitLines(): void {
+        if (!this.logStreamOutput) return;
+
+        while (this.logStreamOutput.children.length > this.maxLines) {
+            this.logStreamOutput.removeChild(this.logStreamOutput.firstChild!);
+        }
+    }
+
+    // --- Search ---
+
+    private openSearch(): void {
+        if (this.searchBar) {
+            this.searchBar.style.display = 'flex';
+            this.searchInput?.focus();
+            this.searchInput?.select();
+        }
+    }
+
+    private closeSearch(): void {
+        if (this.searchBar) this.searchBar.style.display = 'none';
+        this.clearSearch();
+        if (this.searchInput) this.searchInput.value = '';
+    }
+
+    private clearSearch(): void {
+        this.searchMatches.forEach(el => {
+            el.classList.remove('log-search-highlight', 'active');
+            // Restore original text (remove <mark> wrappers)
+            if (el.querySelector('mark')) {
+                el.textContent = el.textContent;
+            }
+        });
+        this.searchMatches = [];
+        this.currentMatchIndex = -1;
+        this.searchTerm = '';
+        if (this.searchCount) this.searchCount.textContent = '';
+    }
+
+    private performSearch(): void {
+        if (!this.logStreamOutput || !this.searchInput) return;
+
+        // Clear previous highlights by restoring textContent
+        const highlighted = this.logStreamOutput.querySelectorAll('.log-search-highlight');
+        highlighted.forEach(el => {
+            el.classList.remove('log-search-highlight', 'active');
+            if (el.querySelector('mark')) {
+                el.textContent = el.textContent;
+            }
+        });
+
+        this.searchMatches = [];
+        this.currentMatchIndex = -1;
+        this.searchTerm = this.searchInput.value.toLowerCase();
+
+        if (!this.searchTerm) {
+            if (this.searchCount) this.searchCount.textContent = '';
+            return;
+        }
+
+        const lines = this.logStreamOutput.querySelectorAll('.log-stream-line');
+        lines.forEach(line => {
+            const el = line as HTMLElement;
+            const text = el.textContent || '';
+            if (text.toLowerCase().includes(this.searchTerm)) {
+                el.classList.add('log-search-highlight');
+                this.searchMatches.push(el);
+            }
+        });
+
+        if (this.searchMatches.length > 0) {
+            this.currentMatchIndex = 0;
+            this.highlightCurrent();
+        }
+
+        this.updateSearchCount();
+    }
+
+    private highlightCurrent(): void {
+        this.searchMatches.forEach(el => el.classList.remove('active'));
+
+        if (this.currentMatchIndex >= 0 && this.currentMatchIndex < this.searchMatches.length) {
+            const current = this.searchMatches[this.currentMatchIndex];
+            current.classList.add('active');
+            current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }
+    }
+
+    private updateSearchCount(): void {
+        if (!this.searchCount) return;
+
+        if (this.searchMatches.length === 0 && this.searchTerm) {
+            this.searchCount.textContent = 'No matches';
+        } else if (this.searchMatches.length > 0) {
+            this.searchCount.textContent = `${this.currentMatchIndex + 1}/${this.searchMatches.length}`;
+        } else {
+            this.searchCount.textContent = '';
+        }
+    }
+
+    private nextMatch(): void {
+        if (this.searchMatches.length === 0) return;
+        this.currentMatchIndex = (this.currentMatchIndex + 1) % this.searchMatches.length;
+        this.highlightCurrent();
+        this.updateSearchCount();
+    }
+
+    private prevMatch(): void {
+        if (this.searchMatches.length === 0) return;
+        this.currentMatchIndex = (this.currentMatchIndex - 1 + this.searchMatches.length) % this.searchMatches.length;
+        this.highlightCurrent();
+        this.updateSearchCount();
+    }
+
+    // --- View switching ---
+
+    private showStreamView(): void {
+        if (this.fileBrowserElement) this.fileBrowserElement.style.display = 'none';
+        if (this.logStreamOutput) this.logStreamOutput.style.display = '';
+        if (this.refreshBtn) this.refreshBtn.style.display = 'none';
+        if (this.clearStreamBtn) this.clearStreamBtn.style.display = '';
+    }
+
+    private showBrowserView(): void {
+        if (this.logStreamOutput) this.logStreamOutput.style.display = 'none';
+        if (this.fileBrowserElement) this.fileBrowserElement.style.display = '';
+        if (this.refreshBtn) this.refreshBtn.style.display = '';
+        if (this.clearStreamBtn) this.clearStreamBtn.style.display = 'none';
+    }
+
+    public async switchToLogView(): Promise<void> {
+        if (this.echoOutput) this.echoOutput.style.display = 'none';
+        if (this.outputLogContainer) this.outputLogContainer.style.display = 'flex';
+        if (this.echoTabBtn) this.echoTabBtn.classList.remove('active');
+        if (this.logStreamTabBtn) this.logStreamTabBtn.classList.add('active');
+        if (this.clearEchoBtn) this.clearEchoBtn.style.display = 'none';
+
+        if (!this.isStreaming) {
+            this.showBrowserView();
+            await (window as any).outputFileBrowser?.show();
+        } else {
+            this.showStreamView();
+        }
+
+        this.updateControls();
+    }
+
+    public switchToEchoView(): void {
+        if (this.echoOutput) this.echoOutput.style.display = '';
+        if (this.outputLogContainer) this.outputLogContainer.style.display = 'none';
+        if (this.echoTabBtn) this.echoTabBtn.classList.add('active');
+        if (this.logStreamTabBtn) this.logStreamTabBtn.classList.remove('active');
+        if (this.clearEchoBtn) this.clearEchoBtn.style.display = '';
+        if (this.refreshBtn) this.refreshBtn.style.display = 'none';
+        if (this.clearStreamBtn) this.clearStreamBtn.style.display = 'none';
+        if (this.stopBtn) this.stopBtn.style.display = 'none';
+        if (this.filenameDisplay) this.filenameDisplay.style.display = 'none';
+        this.closeSearch();
+    }
+
+    private updateControls(): void {
+        if (this.filenameDisplay) {
+            if (this.isStreaming && this.currentFilepath) {
+                const filename = this.currentFilepath.split('/').pop() || this.currentFilepath;
+                this.filenameDisplay.textContent = filename;
+                this.filenameDisplay.style.display = '';
+            } else {
+                this.filenameDisplay.style.display = 'none';
+            }
+        }
+
+        if (this.stopBtn) {
+            const isLogView = this.logStreamTabBtn?.classList.contains('active');
+            this.stopBtn.style.display = this.isStreaming && isLogView ? '' : 'none';
+        }
+    }
+
+    public downloadFile(filepath: string): void {
+        const encodedPath = encodeURIComponent(filepath);
+        const a = document.createElement('a');
+        a.href = `/api/bluesky/output/download/${encodedPath}`;
+        a.download = '';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    }
+
+    public getIsStreaming(): boolean {
+        return this.isStreaming;
+    }
+}
+
+export const logStreamManager = new LogStreamManager();
+
+declare global {
+    interface Window {
+        logStreamManager: LogStreamManager;
+    }
+}
+window.logStreamManager = logStreamManager;

--- a/frontend/src/ui/Modals.ts
+++ b/frontend/src/ui/Modals.ts
@@ -30,7 +30,6 @@ export class Modals {
         // Register all standard modals with the modal manager
         const standardModals = [
             'upload-files-modal',
-            'download-logs-modal',
             'create-aircraft-modal',
             'polygon-name-modal',
             'route-constraints-modal'
@@ -51,8 +50,7 @@ export class Modals {
 
         // Button handlers to open modals
         const modalButtons = [
-            { buttonId: 'upload-files-btn', modalId: 'upload-files-modal' },
-            { buttonId: 'download-logs-btn', modalId: 'download-logs-modal' }
+            { buttonId: 'upload-files-btn', modalId: 'upload-files-modal' }
         ];
 
         modalButtons.forEach(({ buttonId, modalId }) => {
@@ -62,8 +60,7 @@ export class Modals {
                 button.addEventListener('click', (e) => {
                     e.preventDefault();
                     logger.debug('Modals', `Opening modal: ${modalId}`);
-                    
-                    // Special handling for upload files modal
+
                     if (modalId === 'upload-files-modal') {
                         blueSkyFileManager.openModal();
                     } else {
@@ -79,7 +76,6 @@ export class Modals {
         // Close button handlers
         const closeButtons = [
             { buttonId: 'upload-files-close', modalId: 'upload-files-modal' },
-            { buttonId: 'download-logs-close', modalId: 'download-logs-modal' },
             { buttonId: 'create-aircraft-modal-close', modalId: 'create-aircraft-modal' },
             { buttonId: 'polygon-name-modal-close', modalId: 'polygon-name-modal' }
         ];
@@ -88,7 +84,6 @@ export class Modals {
             const button = document.getElementById(buttonId);
             if (button) {
                 button.addEventListener('click', () => {
-                    // Special handling for upload files modal
                     if (modalId === 'upload-files-modal') {
                         blueSkyFileManager.closeModal();
                     } else {
@@ -98,17 +93,6 @@ export class Modals {
             }
         });
 
-        // OK button handlers (typically just close the modal)
-        const okButtons = [
-            { buttonId: 'download-logs-ok', modalId: 'download-logs-modal' }
-        ];
-
-        okButtons.forEach(({ buttonId, modalId }) => {
-            const button = document.getElementById(buttonId);
-            if (button) {
-                button.addEventListener('click', () => this.closeModal(modalId));
-            }
-        });
 
         // Cancel button handlers for aircraft and polygon modals
         // Note: These modals have special functionality managed by their respective managers

--- a/frontend/src/ui/OutputFileBrowser.ts
+++ b/frontend/src/ui/OutputFileBrowser.ts
@@ -1,0 +1,249 @@
+import { logger } from '../utils/Logger';
+
+interface OutputFile {
+    filename: string;
+    size: number;
+    modified: number;
+    type: 'file' | 'folder';
+}
+
+interface Breadcrumb {
+    name: string;
+    path: string;
+}
+
+interface BrowseResponse {
+    success: boolean;
+    file_type: string;
+    files: OutputFile[];
+    current_path: string;
+    breadcrumbs: Breadcrumb[];
+    base_path: string;
+    error?: string;
+}
+
+interface FileStatusResponse {
+    configured: boolean;
+    base_path?: string;
+    derived_paths?: {
+        scenario: string;
+        plugins: string;
+        settings: string;
+        output: string;
+    };
+    path_exists?: boolean;
+    path_writable?: boolean;
+}
+
+export class OutputFileBrowser {
+    private currentPath: string = '';
+    private isConfigured: boolean = false;
+    private fileListElement: HTMLElement | null = null;
+    private notConfiguredElement: HTMLElement | null = null;
+    private browserElement: HTMLElement | null = null;
+    private searchInput: HTMLElement | null = null;
+    private isInitialized = false;
+
+    private lastFiles: OutputFile[] = [];
+    private lastBreadcrumbs: Breadcrumb[] = [];
+    private searchFilter: string = '';
+
+    constructor() {
+        this.init();
+    }
+
+    private init(): void {
+        if (this.isInitialized) return;
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => this.initializeElements());
+        } else {
+            this.initializeElements();
+        }
+    }
+
+    private initializeElements(): void {
+        this.fileListElement = document.getElementById('output-file-list');
+        this.notConfiguredElement = document.getElementById('output-not-configured');
+        this.browserElement = document.getElementById('output-file-browser');
+        this.searchInput = document.getElementById('output-search-input');
+
+        if (this.searchInput) {
+            this.searchInput.addEventListener('input', (e) => {
+                this.searchFilter = (e.target as HTMLInputElement).value.toLowerCase();
+                this.renderFileList(this.lastFiles, this.lastBreadcrumbs);
+            });
+        }
+
+        this.isInitialized = true;
+        logger.debug('OutputFileBrowser', 'Initialized');
+    }
+
+    public async show(): Promise<void> {
+        await this.checkConfiguration();
+
+        if (this.isConfigured) {
+            if (this.notConfiguredElement) this.notConfiguredElement.style.display = 'none';
+            if (this.browserElement) this.browserElement.style.display = '';
+            this.currentPath = '';
+            this.searchFilter = '';
+            if (this.searchInput) (this.searchInput as HTMLInputElement).value = '';
+            await this.refreshFileList();
+        } else {
+            if (this.notConfiguredElement) this.notConfiguredElement.style.display = '';
+            if (this.browserElement) this.browserElement.style.display = '';
+            if (this.fileListElement) this.fileListElement.innerHTML = '';
+        }
+    }
+
+    private async checkConfiguration(): Promise<void> {
+        try {
+            const response = await fetch('/api/bluesky/filestatus');
+            const result: FileStatusResponse = await response.json();
+            this.isConfigured = result.configured === true && result.path_exists === true;
+        } catch (error) {
+            logger.error('OutputFileBrowser', 'Failed to check configuration:', error);
+            this.isConfigured = false;
+        }
+    }
+
+    public async refreshFileList(): Promise<void> {
+        if (!this.isConfigured || !this.fileListElement) return;
+
+        try {
+            const url = this.currentPath
+                ? `/api/bluesky/browse/output/${encodeURIComponent(this.currentPath)}`
+                : '/api/bluesky/browse/output';
+
+            const response = await fetch(url);
+            const result: BrowseResponse = await response.json();
+
+            if (result.success) {
+                this.lastFiles = result.files;
+                this.lastBreadcrumbs = result.breadcrumbs;
+                this.renderFileList(result.files, result.breadcrumbs);
+            } else {
+                this.fileListElement.innerHTML =
+                    '<div class="output-browser-message output-browser-error">Error loading files</div>';
+            }
+        } catch (error) {
+            logger.error('OutputFileBrowser', 'Failed to load file list:', error);
+            if (this.fileListElement) {
+                this.fileListElement.innerHTML =
+                    '<div class="output-browser-message output-browser-error">Failed to load files</div>';
+            }
+        }
+    }
+
+    private renderFileList(files: OutputFile[], breadcrumbs?: Breadcrumb[]): void {
+        if (!this.fileListElement) return;
+
+        let content = '';
+
+        if (breadcrumbs && breadcrumbs.length > 1) {
+            const breadcrumbItems = breadcrumbs.map((crumb, index) => {
+                const isLast = index === breadcrumbs.length - 1;
+                const clickHandler = isLast
+                    ? ''
+                    : `onclick="outputFileBrowser.navigateToPath('${crumb.path}')"`;
+                const cls = isLast ? 'output-crumb-active' : 'output-crumb-link';
+                return `<span class="${cls}" ${clickHandler}>${crumb.name}</span>`;
+            }).join(' <span class="output-crumb-sep">/</span> ');
+
+            content += `<div class="output-breadcrumbs">${breadcrumbItems}</div>`;
+        }
+
+        // Sort: folders first (alphabetical), then files by most recently modified
+        const folders = files
+            .filter(f => f.type === 'folder')
+            .sort((a, b) => a.filename.localeCompare(b.filename));
+        const regularFiles = files
+            .filter(f => f.type === 'file')
+            .sort((a, b) => b.modified - a.modified);
+
+        let sorted = [...folders, ...regularFiles];
+
+        // Apply search filter
+        if (this.searchFilter) {
+            sorted = sorted.filter(f =>
+                f.filename.toLowerCase().includes(this.searchFilter)
+            );
+        }
+
+        if (sorted.length === 0) {
+            const msg = this.searchFilter ? 'No matching files' : 'No output files found';
+            content += `<div class="output-browser-message">${msg}</div>`;
+            this.fileListElement.innerHTML = content;
+            return;
+        }
+
+        const fileItems = sorted.map(file => {
+            const modifiedDate = new Date(file.modified * 1000).toLocaleDateString();
+            const modifiedTime = new Date(file.modified * 1000).toLocaleTimeString();
+            const isFolder = file.type === 'folder';
+            const sizeText = isFolder ? '' : this.formatFileSize(file.size);
+            const filePath = this.currentPath
+                ? `${this.currentPath}/${file.filename}`
+                : file.filename;
+
+            if (isFolder) {
+                return `<div class="output-file-row output-folder-row" onclick="outputFileBrowser.navigateToFolder('${file.filename}')">
+                    <span class="output-file-icon">📁</span>
+                    <span class="output-file-name">${file.filename}</span>
+                </div>`;
+            }
+
+            return `<div class="output-file-row">
+                <span class="output-file-icon">📄</span>
+                <span class="output-file-name">${file.filename}</span>
+                <span class="output-file-meta">${sizeText} &bull; ${modifiedDate} ${modifiedTime}</span>
+                <span class="output-file-actions">
+                    <button class="console-btn" onclick="outputFileBrowser.streamFile('${filePath}')">▶ Stream</button>
+                    <button class="console-btn" onclick="outputFileBrowser.downloadFile('${filePath}')">⬇ Download</button>
+                </span>
+            </div>`;
+        }).join('');
+
+        content += fileItems;
+        this.fileListElement.innerHTML = content;
+    }
+
+    private formatFileSize(bytes: number): string {
+        if (bytes < 1024) return `${bytes} B`;
+        if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+        return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    }
+
+    public async navigateToFolder(folderName: string): Promise<void> {
+        this.currentPath = this.currentPath
+            ? `${this.currentPath}/${folderName}`
+            : folderName;
+        this.searchFilter = '';
+        if (this.searchInput) (this.searchInput as HTMLInputElement).value = '';
+        await this.refreshFileList();
+    }
+
+    public async navigateToPath(path: string): Promise<void> {
+        this.currentPath = path;
+        this.searchFilter = '';
+        if (this.searchInput) (this.searchInput as HTMLInputElement).value = '';
+        await this.refreshFileList();
+    }
+
+    public streamFile(filepath: string): void {
+        (window as any).logStreamManager?.startStreaming(filepath);
+    }
+
+    public downloadFile(filepath: string): void {
+        (window as any).logStreamManager?.downloadFile(filepath);
+    }
+}
+
+export const outputFileBrowser = new OutputFileBrowser();
+
+declare global {
+    interface Window {
+        outputFileBrowser: OutputFileBrowser;
+    }
+}
+window.outputFileBrowser = outputFileBrowser;


### PR DESCRIPTION
Replace the "Download Simulation Logs" stub with a full output file browser
that supports browsing the BlueSky output/ directory, downloading files, and
live-streaming log content in the echo section with a tab toggle.

Backend: add output to browse/list endpoints, add download and content
streaming routes with directory traversal protection.

Frontend: new OutputFileBrowser modal component, LogStreamManager for
polling-based log streaming in the echo section area with Echo/Output Log tabs.