### PR TITLE
fix(ci): include world.pmtiles offline map in published Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # The world.pmtiles offline map is gitignored (~520MB) and shipped via
+      # the prebuilt release tarball, so a fresh checkout has no tile. Pull it
+      # from the most recent published release so the resulting image contains
+      # a working offline basemap. Note: when the tile itself changes, the new
+      # tile lands in Docker one release after the tarball is published (this
+      # workflow runs before the current tag's release is created).
+      - name: Hydrate world.pmtiles from latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/prebuilt WebATM/static/tiles
+          LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          echo "Pulling world.pmtiles from release: $LATEST_TAG"
+          gh release download "$LATEST_TAG" \
+            --pattern 'webatm-prebuilt-*.tar.gz' \
+            --dir /tmp/prebuilt
+          tar -xzf /tmp/prebuilt/webatm-prebuilt-*.tar.gz \
+            -C . WebATM/static/tiles/world.pmtiles
+          ls -lh WebATM/static/tiles/world.pmtiles
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
## Summary
The offline basemap at `WebATM/static/tiles/world.pmtiles` is gitignored (~520MB) and only ships in the prebuilt release tarball. The Docker publish workflow does a fresh `actions/checkout`, so the build context never had the tile — `COPY WebATM/ ./WebATM/` was copying an empty `tiles/` directory, and the published `ghcr.io/amvlab/webatm` image has been shipping without the offline map.

This adds a step that pulls the tile out of the latest published release's `webatm-prebuilt-*.tar.gz` and places it in the build context before `docker buildx` runs. Everything else under `WebATM/static/` is either tracked in git (`css/`, `map/`, `models/`, `favicon.png`) or rebuilt inside the Dockerfile (`dist/`, `vendor/`), so the tile was the only gap.

### Tile-update cadence
Because the current tag's release is created _after_ this workflow runs, when the tile itself changes the new tile will land in the Docker image one release after the tarball is first published. Accepted trade-off for the simplicity of "always pull from latest existing release."

## Test plan
- [ ] After merge: bump to 0.2.2, run `script/build_release_tarball.sh`, create release, observe `docker-publish.yml` run pull `webatm-prebuilt-0.2.1.tar.gz` and bake the tile in
- [ ] Pull `ghcr.io/amvlab/webatm:0.2.2` and confirm `/WebATM/static/tiles/world.pmtiles` is present and the offline basemap loads in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)