### PR TITLE
Fix 3D renderer HiDPI distortion and map view restoration

### DIFF
--- a/frontend/src/ui/map/MapOverlay.ts
+++ b/frontend/src/ui/map/MapOverlay.ts
@@ -560,6 +560,20 @@ export class MapOverlay {
 
         logger.info('MapOverlay', 'Disabling 3D overlay...');
 
+        // Save current view state before removing the 3D layer. Removing the
+        // Three.js custom layer disrupts MapLibre's viewport/projection the same
+        // way adding it does, which otherwise snaps the map back to its default
+        // view. We restore the saved view once the map settles.
+        const map = this.mapDisplay.getMap();
+        const savedView = map
+            ? {
+                  center: map.getCenter(),
+                  zoom: map.getZoom(),
+                  pitch: map.getPitch(),
+                  bearing: map.getBearing()
+              }
+            : null;
+
         if (this.aircraftRoute3DRenderer) {
             this.aircraftRoute3DRenderer.destroy();
             this.aircraftRoute3DRenderer = null;
@@ -571,6 +585,15 @@ export class MapOverlay {
         }
 
         this.is3DOverlayActive = false;
+
+        // Restore the view after the map settles from removing the 3D layer.
+        if (map && savedView) {
+            map.once('idle', () => {
+                map.jumpTo(savedView);
+                this.mapDisplay.resize();
+            });
+        }
+
         logger.info('MapOverlay', '3D overlay disabled');
     }
 

--- a/frontend/src/ui/map/rendering/CustomLayer3D.ts
+++ b/frontend/src/ui/map/rendering/CustomLayer3D.ts
@@ -53,8 +53,13 @@ export abstract class CustomLayer3D implements CustomLayerInterface {
         // Don't auto-clear - MapLibre manages the clear
         this.renderer.autoClear = false;
 
-        // Set pixel ratio for high-DPI displays (reduces graininess)
-        this.renderer.setPixelRatio(window.devicePixelRatio);
+        // Match the Three.js drawing buffer to MapLibre's canvas buffer.
+        // MapLibre already sizes the canvas for the device pixel ratio (e.g. 2x on
+        // Retina), so we keep Three's pixelRatio at 1 and size it to the physical
+        // buffer. Calling setPixelRatio(devicePixelRatio) here would instead make
+        // Three's WebGL viewport twice the canvas size on HiDPI displays, distorting
+        // the scene until a manual window resize re-synced it.
+        this.syncRendererSize();
 
         // Set color space for accurate color rendering
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
@@ -65,6 +70,29 @@ export abstract class CustomLayer3D implements CustomLayerInterface {
 
         // Subclass-specific initialization
         this.onSceneReady();
+    }
+
+    /**
+     * Keep the Three.js renderer's drawing buffer matched to MapLibre's canvas.
+     *
+     * The renderer shares MapLibre's canvas and GL context. MapLibre owns the
+     * drawing-buffer size (already scaled for the device pixel ratio), so we mirror
+     * that physical size into Three with pixelRatio = 1. This avoids the HiDPI/Retina
+     * distortion that occurs when Three's viewport drifts out of sync with the canvas,
+     * and self-heals on every window/canvas resize.
+     */
+    private syncRendererSize(): void {
+        const canvas = this.map.getCanvas();
+        const size = this.renderer.getSize(new THREE.Vector2());
+        if (
+            this.renderer.getPixelRatio() !== 1 ||
+            size.width !== canvas.width ||
+            size.height !== canvas.height
+        ) {
+            this.renderer.setPixelRatio(1);
+            // updateStyle = false: never touch the canvas CSS; MapLibre owns layout.
+            this.renderer.setSize(canvas.width, canvas.height, false);
+        }
     }
 
     /**
@@ -106,6 +134,10 @@ export abstract class CustomLayer3D implements CustomLayerInterface {
         const args = Array.isArray(matrixOrArgs)
             ? { defaultProjectionData: { mainMatrix: matrixOrArgs } }
             : matrixOrArgs;
+
+        // Keep the renderer's drawing buffer in sync with MapLibre's canvas so the
+        // WebGL viewport stays correct after resizes / DPR changes (Retina toggles).
+        this.syncRendererSize();
 
         // Update scene objects first (subclass may override camera projection)
         this.updateScene(args);


### PR DESCRIPTION
## Summary
Issue #26 resolved 

Fixes two issues with the 3D overlay rendering: (1) HiDPI/Retina display distortion caused by Three.js pixel ratio mismatch with MapLibre's canvas, and (2) map view snapping to default when disabling the 3D overlay.

## Key Changes

**CustomLayer3D.ts:**
- Replaced direct `setPixelRatio(devicePixelRatio)` call with a new `syncRendererSize()` method that keeps Three.js renderer's drawing buffer synchronized with MapLibre's canvas
- Set Three.js pixel ratio to 1 and match the physical canvas dimensions instead, since MapLibre already handles device pixel ratio scaling
- Added `syncRendererSize()` call in the render loop to self-heal after window/canvas resizes or DPR changes (e.g., Retina display toggles)
- Includes detailed comments explaining the HiDPI synchronization strategy

**MapOverlay.ts:**
- Save map view state (center, zoom, pitch, bearing) before removing the 3D layer
- Restore the saved view after the map settles from the layer removal, preventing the map from snapping back to its default view
- Trigger a map resize after restoration to ensure proper layout

## Implementation Details
The Three.js renderer shares MapLibre's canvas and GL context. MapLibre owns the drawing-buffer size (already scaled for device pixel ratio), so syncing with `pixelRatio = 1` avoids the viewport drift that caused distortion on HiDPI displays. The sync is performed on every render frame to automatically correct any misalignment after resizes or DPR changes.
