### PR TITLE
fix(frontend): add node to tsconfig types for TypeScript 6

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ES2020",
     "moduleResolution": "bundler",
     "lib": ["ES2020", "DOM"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Problem

After the TypeScript bump to 6.0.3 (#35), `script/build_frontend.sh` fails with:

```
ERROR in src/utils/Logger.ts
TS2591: Cannot find name 'process'. Do you need to install type definitions for node?
```

TypeScript 6 with `moduleResolution: "bundler"` no longer auto-includes the global `process` from `@types/node` when no explicit `types` field is present in tsconfig. `@types/node` was already a dependency, but its globals weren't being loaded.

## Fix

Add `"types": ["node"]` to `frontend/tsconfig.json`. This restores the `process` global type used by the runtime-guarded environment check in `Logger.ts`.

Other `@types` packages (three, geojson, supercluster, etc.) are resolved through `import` statements, so they are unaffected by the `types` field.

## Verification

- `npx tsc --noEmit` → exit 0 (was 3 errors)
- Frontend build now compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)