### PR TITLE
Link header simulation time to the active node

### DIFF
--- a/WebATM/proxy/handlers/simulation.py
+++ b/WebATM/proxy/handlers/simulation.py
@@ -67,9 +67,9 @@ def on_siminfo_received(
         "scenname": str(scenname) if scenname is not None else "",
         "sender_id": sender_id_str,  # Include sender ID for node identification
     }
-    proxy.sim_data = sim_data
 
-    # Update node information like web client does
+    # Update per-node tracking for EVERY node so the Simulation Nodes panel
+    # shows each node's own clock, regardless of which node is currently active.
     if sender_id_str and sender_id_str in proxy.tracked_nodes:
         simt_str = tim2txt(simt)[:-3] if simt is not None else "00:00:00"
         proxy.tracked_nodes[sender_id_str].update(
@@ -78,6 +78,21 @@ def on_siminfo_received(
         # Emit updated node info occasionally (not every frame to avoid spam)
         if int(simt or 0) % 5 == 0:  # Every 5 seconds
             proxy._emit_node_info()
+
+    # The header clock/rate/state must follow the ACTIVE node only, not
+    # whichever node sent the latest update. Otherwise, with two or more nodes
+    # running, the displayed time jumps between them. Cache and emit the sim
+    # info solely for the active node. When the active node can't be resolved
+    # yet (e.g. early in connection setup, before act_id is known), fall back to
+    # accepting any sender so a single-node display still works.
+    active_node = proxy._get_safe_active_node()
+    is_active_node = (
+        active_node is None or sender_id_str is None or sender_id_str == active_node
+    )
+    if not is_active_node:
+        return
+
+    proxy.sim_data = sim_data
 
     # Throttle sim info emissions
     current_time = time.time()


### PR DESCRIPTION
## Summary
Fixed an issue where the simulation header clock, rate, and state would jump between different nodes in multi-node scenarios. The header now only updates based on the active node, while per-node tracking continues to update for all nodes independently. Addresses #56.

## Changes
- **Separated header updates from per-node tracking**: The simulation info handler now maintains two distinct update paths:
  - Per-node tracking updates for ALL nodes (so the Simulation Nodes panel shows each node's own clock)
  - Header clock/rate/state updates only for the active node (preventing display jumping)

- **Added active node filtering**: Before caching `sim_data` for header emission, the handler now checks if the sender is the active node using `proxy._get_safe_active_node()`. If a different node sends an update, it's ignored for header purposes.

- **Graceful fallback for early connection setup**: When the active node cannot be resolved yet (e.g., before `act_id` is known), the handler accepts updates from any sender to ensure single-node displays still work correctly.

## Implementation Details
- The active node check uses a three-way condition: accept updates if no active node is set yet, if sender ID is unknown, or if the sender matches the active node
- Early return prevents header emission when a non-active node sends data
- Per-node updates continue unaffected, maintaining accurate individual node state in the UI panels