### PR TITLE
Add toggle to hide the map airport/waypoint search bar

### DIFF
--- a/WebATM/templates/index.html
+++ b/WebATM/templates/index.html
@@ -300,6 +300,10 @@
                                 <input type="checkbox" id="snap-to-navaids" checked>
                                 Snap to Navaids
                             </label>
+                            <label class="checkbox-label" id="show-search-bar-container">
+                                <input type="checkbox" id="show-search-bar" checked>
+                                Search Bar
+                            </label>
 
                             <!-- Aircraft Display Options -->
                             <div class="aircraft-appearance-controls">

--- a/frontend/src/core/App.ts
+++ b/frontend/src/core/App.ts
@@ -204,6 +204,10 @@ export class App {
                 // Update map overlay with new display options
                 this.mapOverlay.updateDisplayOptions(newOptions);
             }
+            // Toggle the airport/waypoint search bar visibility
+            if (newOptions) {
+                this.navSearchBox?.setVisible(newOptions.showSearchBar);
+            }
         });
 
         // Subscribe to selected aircraft changes
@@ -481,9 +485,11 @@ export class App {
         // This needs to happen after AircraftInteractionManager creation to check for explicit POS commands
         this.setupRouteDataHandler();
 
-        // Initialize the airport/waypoint "go to" search box.
+        // Initialize the airport/waypoint "go to" search box, applying the
+        // saved show/hide preference.
         this.navSearchBox = new NavSearchBox(this.mapDisplay);
         this.navSearchBox.init();
+        this.navSearchBox.setVisible(this.stateManager.getDisplayOptions().showSearchBar);
 
         // Connect managers to MapControlsPanel
         this.mapControlsPanel.setShapeDrawingManager(this.shapeDrawingManager);

--- a/frontend/src/core/StateManager.ts
+++ b/frontend/src/core/StateManager.ts
@@ -96,6 +96,8 @@ export class StateManager {
                 showRunwayLabels: true,
                 showPavement: true,
                 snapToNavaids: true,
+                // Search bar is visible by default.
+                showSearchBar: true,
                 airportColor: '#4da3ff',
                 heliportColor: '#e0823c',
                 waypointColor: '#9aa7b4',

--- a/frontend/src/data/types.ts
+++ b/frontend/src/data/types.ts
@@ -532,6 +532,8 @@ export interface DisplayOptions {
   showPavement: boolean;
   // Snap drawing/creation clicks to the nearest navaid (airport/heliport/waypoint).
   snapToNavaids: boolean;
+  // Show the airport/waypoint "go to" search bar at the top of the map.
+  showSearchBar: boolean;
   airportColor: string;
   heliportColor: string;
   waypointColor: string;

--- a/frontend/src/ui/map/navdata/NavSearchBox.test.ts
+++ b/frontend/src/ui/map/navdata/NavSearchBox.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+/**
+ * Tests for NavSearchBox.setVisible - the show/hide behaviour behind the
+ * "Search Bar" display option. Only the visibility logic is covered here;
+ * the search/fetch flow needs the navdata backend.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NavSearchBox } from './NavSearchBox';
+import type { MapDisplay } from '../MapDisplay';
+
+function mountMarkup(): void {
+    document.body.innerHTML = `
+        <div id="nav-search" class="nav-search">
+            <input id="nav-search-input" type="text">
+            <div id="nav-search-results" style="display: none;"></div>
+        </div>
+    `;
+}
+
+function createMapDisplayMock(): MapDisplay {
+    return { setCenter: vi.fn() } as unknown as MapDisplay;
+}
+
+describe('NavSearchBox.setVisible', () => {
+    let box: NavSearchBox;
+
+    beforeEach(() => {
+        mountMarkup();
+        box = new NavSearchBox(createMapDisplayMock());
+        box.init();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    const container = () => document.getElementById('nav-search') as HTMLElement;
+    const results = () => document.getElementById('nav-search-results') as HTMLElement;
+
+    it('hides the search box by setting display:none', () => {
+        box.setVisible(false);
+        expect(container().style.display).toBe('none');
+    });
+
+    it('shows the search box by clearing the inline display', () => {
+        box.setVisible(false);
+        box.setVisible(true);
+        // Empty string reverts to the stylesheet's default (visible).
+        expect(container().style.display).toBe('');
+    });
+
+    it('closes the results dropdown when hidden', () => {
+        // Pretend the dropdown was open.
+        results().style.display = 'block';
+        box.setVisible(false);
+        expect(results().style.display).toBe('none');
+    });
+
+    it('is a safe no-op when the markup is absent (init not run)', () => {
+        const orphan = new NavSearchBox(createMapDisplayMock());
+        expect(() => orphan.setVisible(false)).not.toThrow();
+        expect(() => orphan.setVisible(true)).not.toThrow();
+    });
+});

--- a/frontend/src/ui/map/navdata/NavSearchBox.ts
+++ b/frontend/src/ui/map/navdata/NavSearchBox.ts
@@ -20,6 +20,7 @@ interface NavSearchResult {
  */
 export class NavSearchBox {
     private mapDisplay: MapDisplay;
+    private container: HTMLElement | null = null;
     private input: HTMLInputElement | null = null;
     private results: HTMLElement | null = null;
     private debounceTimer: number | null = null;
@@ -35,6 +36,7 @@ export class NavSearchBox {
     }
 
     public init(): void {
+        this.container = document.getElementById('nav-search');
         this.input = document.getElementById('nav-search-input') as HTMLInputElement | null;
         this.results = document.getElementById('nav-search-results');
         if (!this.input || !this.results) {
@@ -54,6 +56,16 @@ export class NavSearchBox {
         });
 
         logger.debug('NavSearchBox', 'Initialized');
+    }
+
+    /**
+     * Show or hide the search box. Hiding also closes any open results
+     * dropdown so it doesn't linger when the widget reappears.
+     */
+    public setVisible(visible: boolean): void {
+        if (!this.container) return;
+        this.container.style.display = visible ? '' : 'none';
+        if (!visible) this.hideResults();
     }
 
     private onInput(): void {

--- a/frontend/src/ui/panels/left/DisplayOptionsPanel.ts
+++ b/frontend/src/ui/panels/left/DisplayOptionsPanel.ts
@@ -201,6 +201,7 @@ export class DisplayOptionsPanel extends BasePanel {
         const showRunwayLabels = storage.get<boolean>('show-runway-labels') ?? displayOptions.showRunwayLabels;
         const showPavement = storage.get<boolean>('show-pavement') ?? displayOptions.showPavement;
         const snapToNavaids = storage.get<boolean>('snap-to-navaids') ?? displayOptions.snapToNavaids;
+        const showSearchBar = storage.get<boolean>('show-search-bar') ?? displayOptions.showSearchBar;
 
         // Load route display options from storage
         const showRoutes = storage.get<boolean>('show-routes') ?? displayOptions.showRoutes;
@@ -263,6 +264,7 @@ export class DisplayOptionsPanel extends BasePanel {
             showRunwayLabels,
             showPavement,
             snapToNavaids,
+            showSearchBar,
             showRoutes,
             showRouteLines,
             showRouteLabels,
@@ -341,6 +343,7 @@ export class DisplayOptionsPanel extends BasePanel {
         this.setChecked('show-runway-labels', showRunwayLabels);
         this.setChecked('show-pavement', showPavement);
         this.setChecked('snap-to-navaids', snapToNavaids);
+        this.setChecked('show-search-bar', showSearchBar);
 
         // Update route display checkboxes to reflect loaded values
         this.setChecked('show-routes', showRoutes);
@@ -743,6 +746,7 @@ export class DisplayOptionsPanel extends BasePanel {
             ['show-runway-labels', 'showRunwayLabels'],
             ['show-pavement', 'showPavement'],
             ['snap-to-navaids', 'snapToNavaids'],
+            ['show-search-bar', 'showSearchBar'],
             ['show-routes', 'showRoutes'],
             ['show-route-lines', 'showRouteLines'],
             ['show-route-labels', 'showRouteLabels'],


### PR DESCRIPTION
## Summary
Fixes #51. Adds a "Search Bar" toggle to the Display Options panel, allowing users to show/hide the airport/waypoint search box. The visibility preference is persisted across sessions.

## Key Changes
- **NavSearchBox**: Added `setVisible()` method to control search box visibility and close any open results dropdown when hidden
- **Display Options**: Added `showSearchBar` boolean flag to `DisplayOptions` interface with default value `true`
- **DisplayOptionsPanel**: Integrated search bar visibility toggle into the display options UI with persistent storage
- **App initialization**: Apply saved search bar visibility preference on startup and respond to visibility changes via state manager
- **UI**: Added "Search Bar" checkbox to the Display section of the options panel
- **Tests**: Added comprehensive test suite for `NavSearchBox.setVisible()` covering show/hide behavior, dropdown closure, and safe no-op handling

## Implementation Details
- The search box visibility is controlled by setting `display: none` (hidden) or clearing the inline style (visible)
- Hiding the search box automatically closes any open results dropdown to prevent UI inconsistency
- The implementation gracefully handles cases where the DOM elements haven't been initialized yet
- Visibility state is synchronized with the state manager and persists via browser storage