### PR TITLE
Use a consistent crosshair cursor across all map drawing modes

### DIFF
--- a/frontend/src/ui/ConsoleMapPicker.ts
+++ b/frontend/src/ui/ConsoleMapPicker.ts
@@ -5,6 +5,7 @@ import type { NavaidSnapper } from './map/navdata/NavaidSnapper';
 import { lineStringFeature, pointFeature } from '../utils/geojson';
 import { logger } from '../utils/Logger';
 import {
+    DRAWING_CURSOR,
     ensureGeoJSONSource,
     ensureLayer,
     safeRemoveLayer,
@@ -122,7 +123,7 @@ export class ConsoleMapPicker {
 
         // Crosshair cursor to signal pick mode is live.
         const canvas = map.getCanvas();
-        if (canvas) canvas.style.cursor = 'crosshair';
+        if (canvas) canvas.style.cursor = DRAWING_CURSOR;
 
         // Show the hint text next to the console input.
         this.showHint(ctx.kind);

--- a/frontend/src/ui/map/BaseDrawingManager.ts
+++ b/frontend/src/ui/map/BaseDrawingManager.ts
@@ -1,6 +1,7 @@
 import type { MapDisplay } from './MapDisplay';
 import type { MapMouseEvent } from 'maplibre-gl';
 import type { NavaidSnapper } from './navdata/NavaidSnapper';
+import { DRAWING_CURSOR } from '../../utils/maplibre';
 
 /**
  * BaseDrawingManager - shared interactive point-drawing lifecycle for the
@@ -95,7 +96,7 @@ export abstract class BaseDrawingManager {
         const map = this.mapDisplay.getMap();
         if (!map) return;
 
-        map.getCanvas().style.cursor = 'crosshair';
+        map.getCanvas().style.cursor = DRAWING_CURSOR;
 
         this.onDrawingEnabled();
 

--- a/frontend/src/ui/map/aircraft/AircraftCreationManager.ts
+++ b/frontend/src/ui/map/aircraft/AircraftCreationManager.ts
@@ -2,6 +2,7 @@ import type { GeoJSONSource, MapMouseEvent } from 'maplibre-gl';
 import { MapDisplay } from '../MapDisplay';
 import type { NavaidSnapper } from '../navdata/NavaidSnapper';
 import { logger } from '../../../utils/Logger';
+import { DRAWING_CURSOR } from '../../../utils/maplibre';
 import {
     AircraftCreationForm,
     AircraftCreationData,
@@ -99,6 +100,10 @@ export class AircraftCreationManager {
             return;
         }
 
+        // Match the crosshair cursor used by the console map picker and the
+        // shape/route drawing modes so every drawing mode looks the same.
+        map.getCanvas().style.cursor = DRAWING_CURSOR;
+
         // Add click handler for aircraft positioning
         this.aircraftMapClickHandler = (e: MapMouseEvent) => {
             this.handleAircraftMapClick(e);
@@ -131,6 +136,9 @@ export class AircraftCreationManager {
     private disableAircraftMapDrawing(): void {
         const map = this.mapDisplay.getMap();
         if (!map) return;
+
+        // Restore MapLibre's default cursor when leaving drawing mode.
+        map.getCanvas().style.cursor = '';
 
         if (this.aircraftMapClickHandler) {
             map.off('click', this.aircraftMapClickHandler);

--- a/frontend/src/utils/maplibre.ts
+++ b/frontend/src/utils/maplibre.ts
@@ -11,6 +11,14 @@ const EMPTY_FEATURE_COLLECTION: GeoJSON.FeatureCollection = {
     features: []
 };
 
+/**
+ * Canvas cursor used by every interactive map-drawing mode (console map
+ * picker, shape/route drawing, aircraft creation). Centralised here so all
+ * drawing modes share one consistent pointer. Assign the empty string to
+ * restore MapLibre's default cursor when leaving a drawing mode.
+ */
+export const DRAWING_CURSOR = 'crosshair';
+
 export function ensureGeoJSONSource(
     map: MapLibreMap,
     sourceId: string,


### PR DESCRIPTION
## Summary
Fix #64. Consolidates the cursor styling for all interactive map-drawing modes (aircraft creation, shape/route drawing, and console map picker) by introducing a centralized `DRAWING_CURSOR` constant. This ensures a consistent visual experience across all drawing modes.

## Key Changes
- Added `DRAWING_CURSOR` constant in `frontend/src/utils/maplibre.ts` set to `'crosshair'` with documentation explaining its purpose
- Updated `AircraftCreationManager` to apply the crosshair cursor when entering drawing mode and restore the default cursor when exiting
- Updated `ConsoleMapPicker` to use the centralized `DRAWING_CURSOR` constant instead of hardcoded `'crosshair'`
- Updated `BaseDrawingManager` to use the centralized `DRAWING_CURSOR` constant instead of hardcoded `'crosshair'`

## Implementation Details
- The `DRAWING_CURSOR` constant is exported from the maplibre utilities module and imported by all drawing mode managers
- Cursor is set to the crosshair when entering drawing mode and explicitly restored to an empty string (MapLibre's default) when exiting
- This eliminates code duplication and provides a single source of truth for the drawing mode cursor style